### PR TITLE
patch: optional params

### DIFF
--- a/.changeset/orange-steaks-trade.md
+++ b/.changeset/orange-steaks-trade.md
@@ -1,0 +1,5 @@
+---
+"@wethegit/react-modal": patch
+---
+
+fix: ensures empty params doesn't throw

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "prepare": "node -e \"try { require('husky').install() } catch (e) {if (e.code !== 'MODULE_NOT_FOUND') throw e}\"",
     "start": "vite",
     "build": "rm -rf dist && vite build",
+    "changeset": "changeset",
     "version": "changeset version",
     "release": "npm run build && changeset publish",
     "lint:scripts": "eslint --report-unused-disable-directives --max-warnings 0 --ext .tsx,ts --ignore-path .gitignore .",

--- a/src/lib/hooks/use-modal.ts
+++ b/src/lib/hooks/use-modal.ts
@@ -16,7 +16,8 @@ export interface UseModalOptions {
   hash?: string
 }
 
-export function useModal({ triggerRef, hash }: UseModalOptions) {
+export function useModal(props: UseModalOptions) {
+  const { triggerRef, hash } = props || {}
   const [state, setState] = useState<ModalStates>(ModalStates.CLOSED)
 
   const handleClose = useCallback(() => {


### PR DESCRIPTION
## Description

All parameters of the hook are optional, right now if you don't pass art least an empty object it throws an errors trying to de-structure

## Solution

Ensures we have an empty object.

