### PR TITLE
fix: support commonjs

### DIFF
--- a/.changeset/sharp-zoos-camp.md
+++ b/.changeset/sharp-zoos-camp.md
@@ -1,0 +1,5 @@
+---
+"@wethegit/react-modal": patch
+---
+
+fix: commonjs support

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
       "import": {
         "types": "./dist/main.d.ts",
         "default": "./dist/react-modal.js"
-      }
+      },
+      "require": "./dist/react-modal.js"
     },
     "./style.css": "./dist/style.css"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "types": "./dist/main.d.ts",
         "default": "./dist/react-modal.js"
       },
-      "require": "./dist/react-modal.js"
+      "require": "./dist/react-modal.cjs"
     },
     "./style.css": "./dist/style.css"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       // eslint-disable-next-line no-undef
       entry: resolve(__dirname, "src/lib/index.ts"),
       name: "ReactModal",
-      formats: ["es"],
+      formats: ["es", "cjs"],
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled


### PR DESCRIPTION
## Description

After fixing the types export, the commonjs implementation got messed up as it requires a specific export key or that it be the default path in the `exports` property.