### PR TITLE
Feature: Added renderTo prop instead of appendToBody

### DIFF
--- a/.changeset/perfect-plums-pretend.md
+++ b/.changeset/perfect-plums-pretend.md
@@ -1,0 +1,27 @@
+---
+"@wethegit/react-modal": major
+---
+
+## Breaking changes
+
+- **Removed** `appendToBody` prop.
+  - The `appendToBody` prop has been removed. This prop was previously used to determine whether the modal should be appended to the body element.
+
+## New Features
+
+- **Added** `renderTo` prop.
+  - Introduced the `renderTo` prop, which accepts an HTMLElement where the modal will be appended. This provides greater flexibilty, allowing users to specify any element to render the modal, including the body. This change enhances the customization options for the modal rendering.
+
+## Migration
+
+- **Before**
+
+  ```javascript
+  <Modal appendToBody={true} />
+  ```
+
+- **After**
+
+  ```javascript
+  <Modal renderTo={modalRef} />
+  ```

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Custom transition, focus management and hash-based state management.
 Use your favorite animation library, [@wethegit/react-hooks](https://wethegit.github.io/react-hooks/use-animate-presence) provides a simple one for these cases.
 
 ```jsx
+import { useRef } from 'react'
 import { useAnimatePresence } from '@wethegit/react-hooks'
 import {
   Modal,
@@ -162,7 +163,7 @@ function MyModal() {
 
 | prop                 | type      | default value | description                                                                                                                                                                                                                                                                                            |
 | -------------------- | --------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| renderTo         | String / HTMLElement | null   | Optional. If not provided or the selector/element provided is undefined/null the modal will be appended to document.body<br> If a valid selector string is provided, the modal will be appended to the element returned by document.querySelector(renderTo).<br> 	If a valid HTMLElement is provided, the modal will be appended to that element.                                                                                       |
+| renderTo         | HTMLElement   | null | If a valid HTMLElement is provided, the modal will be appended to that element. Otherwise will be rendered in place.                                                                                       |
 | className            | String    | null          |                                                                                                                                                                                                                                                                                                        |
 | children            | ReactNode | null          |                                                                                                                                                                                                                                                                                                        |
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ import {
 
 function MyModal() {
   const triggerButton = useRef(null)
+  const modalRootRef = useRef(null)
 
   const { isOpen, toggle } = useModal({
     // `triggerRef` allows the focus to shift to whatever triggered the modal
@@ -132,9 +133,12 @@ function MyModal() {
       <button ref={triggerButton} onClick={toggle}>
         Open the modal window!
       </button>
+      <div ref={modalRootRef}></div>
 
-      {render && (
-        <Modal style={{
+      {render && modalRootRef.current && (
+        <Modal 
+          renderTo={modalRootRef.current}
+          style={{
           transition: `opacity 800ms ease-in-out`,
           opacity: animate ? 1 : 0
         }}>
@@ -158,7 +162,7 @@ function MyModal() {
 
 | prop                 | type      | default value | description                                                                                                                                                                                                                                                                                            |
 | -------------------- | --------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| appendToBody         | Boolean   | true          | Optional. Whether to append the Modal markup to the HTML `<body>` element, or to leave it where it exists within your component structure. Setting this to `false` can be useful for "local" dialog boxes.                                                                                             |
+| renderTo         | String / HTMLElement | null   | Optional. If not provided or the selector/element provided is undefined/null the modal will be appended to document.body<br> If a valid selector string is provided, the modal will be appended to the element returned by document.querySelector(renderTo).<br> 	If a valid HTMLElement is provided, the modal will be appended to that element.                                                                                       |
 | className            | String    | null          |                                                                                                                                                                                                                                                                                                        |
 | children            | ReactNode | null          |                                                                                                                                                                                                                                                                                                        |
 

--- a/src/lib/components/modal/modal.tsx
+++ b/src/lib/components/modal/modal.tsx
@@ -6,16 +6,28 @@ import type { ModalInnerProps } from "../modal-inner"
 import { classnames } from "../../../utils/classnames"
 
 import styles from "./modal.module.scss"
-
 export interface ModalProps extends ModalInnerProps {
   /**
-   * If true, the modal will be appended to the body instead of being rendered in place.
-   * @defaultValue true
-   */
-  appendToBody?: boolean
+   * If provided, the modal will be appended to the provided element instead of being rendered in place.
+   * @defaultValue defaults to document.body
+   **/
+  renderTo?: string | HTMLElement
 }
 
-export function Modal({ appendToBody, className, ...props }: ModalProps) {
+const getModalRoot = (renderTo?: string | HTMLElement) => {
+  if (typeof renderTo === "string") {
+    if (renderTo === "parent") return
+
+    return document.querySelector(renderTo) || document.body
+  }
+
+  return renderTo || document.body
+}
+
+export function Modal({ renderTo, className, ...props }: ModalProps) {
+  const modalRoot = getModalRoot(renderTo)
+  const appendToBody = modalRoot === document.body
+
   usePreventScroll(appendToBody)
 
   const classes = classnames([
@@ -23,12 +35,11 @@ export function Modal({ appendToBody, className, ...props }: ModalProps) {
     className,
   ])
 
-  if (appendToBody) {
-    return ReactDOM.createPortal(
-      <ModalInner className={classes} {...props} />,
-      document.body
-    )
-  } else {
-    return <ModalInner className={classes} {...props} />
+  const modalContent = <ModalInner className={classes} {...props} />
+
+  if (modalRoot) {
+    return ReactDOM.createPortal(modalContent, modalRoot)
   }
+
+  return modalContent
 }

--- a/src/lib/components/modal/modal.tsx
+++ b/src/lib/components/modal/modal.tsx
@@ -1,50 +1,26 @@
-import ReactDOM from "react-dom"
-import { usePreventScroll } from "@wethegit/react-hooks"
+"use client"
 
+import ReactDOM from "react-dom"
 import { ModalInner } from "../modal-inner"
 import type { ModalInnerProps } from "../modal-inner"
 import { classnames } from "../../../utils/classnames"
 
 import styles from "./modal.module.scss"
-import { useMemo } from "react"
 export interface ModalProps extends ModalInnerProps {
   /**
-   * If provided, the modal will be appended to the provided element instead of being rendered in body
-   * @defaultValue defaults to document.body
+   * The modal will be appended to the passed element instead of being rendered in place
+   * @defaultValue defaults inPlace
    **/
-  renderTo?: string | HTMLElement
+  renderTo: HTMLElement
 }
 
 export function Modal({ renderTo, className, ...props }: ModalProps) {
-  const isClient = typeof window !== "undefined" && typeof document !== "undefined"
-  // get modalRoot
-  const modalRoot = useMemo(() => {
-    if (!isClient) return null
-
-    if (typeof renderTo === "string") {
-      const element = document.querySelector(renderTo)
-      if (element) return element
-      // Console error when element not found
-      console.error(`Element not found for selector: ${renderTo}`)
-      return null
-    }
-
-    return renderTo || document.body
-  }, [renderTo, isClient])
-
-  const lockScrolling = isClient ? modalRoot === document.body : false
-
-  usePreventScroll(lockScrolling)
-
-  const classes = classnames([
-    lockScrolling ? styles.ModalFixed : styles.ModalAbsolute,
-    className,
-  ])
+  const classes = classnames([styles.ModalFixed, className])
 
   const modalContent = <ModalInner className={classes} {...props} />
 
-  if (modalRoot) {
-    return ReactDOM.createPortal(modalContent, modalRoot)
+  if (renderTo) {
+    return ReactDOM.createPortal(modalContent, renderTo)
   }
 
   return modalContent

--- a/src/lib/components/modal/modal.tsx
+++ b/src/lib/components/modal/modal.tsx
@@ -15,16 +15,20 @@ export interface ModalProps extends ModalInnerProps {
 }
 
 const getModalRoot = (renderTo?: string | HTMLElement) => {
-  if (typeof renderTo === "string") {
-    return document.querySelector(renderTo) || document.body
+  if (typeof window !== "undefined") {
+    if (typeof renderTo === "string") {
+      return document.querySelector(renderTo) || document.body
+    }
+
+    return renderTo || document.body
   }
 
-  return renderTo || document.body
+  return null
 }
 
 export function Modal({ renderTo, className, ...props }: ModalProps) {
   const modalRoot = getModalRoot(renderTo)
-  const appendToBody = modalRoot === document.body
+  const appendToBody = modalRoot ? modalRoot === document.body : false
 
   usePreventScroll(appendToBody)
 

--- a/src/lib/components/modal/modal.tsx
+++ b/src/lib/components/modal/modal.tsx
@@ -8,7 +8,7 @@ import { classnames } from "../../../utils/classnames"
 import styles from "./modal.module.scss"
 export interface ModalProps extends ModalInnerProps {
   /**
-   * If provided, the modal will be appended to the provided element instead of being rendered in place.
+   * If provided, the modal will be appended to the provided element instead of being rendered in body
    * @defaultValue defaults to document.body
    **/
   renderTo?: string | HTMLElement
@@ -16,8 +16,6 @@ export interface ModalProps extends ModalInnerProps {
 
 const getModalRoot = (renderTo?: string | HTMLElement) => {
   if (typeof renderTo === "string") {
-    if (renderTo === "parent") return
-
     return document.querySelector(renderTo) || document.body
   }
 

--- a/src/lib/components/modal/modal.tsx
+++ b/src/lib/components/modal/modal.tsx
@@ -6,6 +6,7 @@ import type { ModalInnerProps } from "../modal-inner"
 import { classnames } from "../../../utils/classnames"
 
 import styles from "./modal.module.scss"
+import { useMemo } from "react"
 export interface ModalProps extends ModalInnerProps {
   /**
    * If provided, the modal will be appended to the provided element instead of being rendered in body
@@ -14,26 +15,29 @@ export interface ModalProps extends ModalInnerProps {
   renderTo?: string | HTMLElement
 }
 
-const getModalRoot = (renderTo?: string | HTMLElement) => {
-  if (typeof window !== "undefined") {
+export function Modal({ renderTo, className, ...props }: ModalProps) {
+  const isClient = typeof window !== "undefined" && typeof document !== "undefined"
+  // get modalRoot
+  const modalRoot = useMemo(() => {
+    if (!isClient) return null
+
     if (typeof renderTo === "string") {
-      return document.querySelector(renderTo) || document.body
+      const element = document.querySelector(renderTo)
+      if (element) return element
+      // Console error when element not found
+      console.error(`Element not found for selector: ${renderTo}`)
+      return null
     }
 
     return renderTo || document.body
-  }
+  }, [renderTo, isClient])
 
-  return null
-}
+  const lockScrolling = isClient ? modalRoot === document.body : false
 
-export function Modal({ renderTo, className, ...props }: ModalProps) {
-  const modalRoot = getModalRoot(renderTo)
-  const appendToBody = modalRoot ? modalRoot === document.body : false
-
-  usePreventScroll(appendToBody)
+  usePreventScroll(lockScrolling)
 
   const classes = classnames([
-    appendToBody ? styles.ModalFixed : styles.ModalAbsolute,
+    lockScrolling ? styles.ModalFixed : styles.ModalAbsolute,
     className,
   ])
 

--- a/src/main.module.css
+++ b/src/main.module.css
@@ -31,3 +31,7 @@
   --ease: cubic-bezier(0.77, 0, 0.1, 1.39);
   --scale: 1;
 }
+
+.CustomModalAbsolute {
+  position: absolute;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import styles from "./main.module.css"
 
 function CustomModal() {
   const triggerButton = useRef(null)
+  const modalRootRef = useRef(null)
   const { isOpen, toggle } = useModal({
     triggerRef: triggerButton,
   })
@@ -16,39 +17,12 @@ function CustomModal() {
     <>
       {/* `triggerRef` allows the focus to shift to whatever triggered the modal, on close. */}
       <button ref={triggerButton} onClick={toggle}>
-        Open the modal (body)
+        Open the modal (HTMLElement)
       </button>
+      <div ref={modalRootRef}></div>
 
-      {isOpen && (
-        <Modal>
-          <ModalBackdrop onClick={toggle} className={styles.CustomModalOverlay} />
-          <ModalContent className={classnames([styles.CustomModalContent])}>
-            <button onClick={toggle} className={styles.CustomModalClose}>
-              Close
-            </button>
-            <p>Voluptate Lorem ut minim excepteur sit fugiat anim magna aliquip.</p>
-          </ModalContent>
-        </Modal>
-      )}
-    </>
-  )
-}
-
-function ModalWithSelector() {
-  const triggerButton = useRef(null)
-  const { isOpen, toggle } = useModal({
-    triggerRef: triggerButton,
-  })
-
-  return (
-    <>
-      {/* `triggerRef` allows the focus to shift to whatever triggered the modal, on close. */}
-      <button ref={triggerButton} onClick={toggle}>
-        Open the modal (selector)
-      </button>
-
-      {isOpen && (
-        <Modal renderTo={".modal-selector"}>
+      {isOpen && modalRootRef.current && (
+        <Modal renderTo={modalRootRef.current}>
           <ModalBackdrop onClick={toggle} className={styles.CustomModalOverlay} />
           <ModalContent className={classnames([styles.CustomModalContent])}>
             <button onClick={toggle} className={styles.CustomModalClose}>
@@ -73,9 +47,9 @@ function ModalWithHash() {
   return (
     <>
       <button ref={triggerButton} onClick={toggle}>
-        Using a hash (HTMLElement)
+        Using a hash
       </button>
-      <div ref={modalRootRef} className="modal-ref"></div>
+      <div ref={modalRootRef}></div>
 
       {isOpen && modalRootRef.current && (
         <Modal renderTo={modalRootRef.current}>
@@ -96,9 +70,7 @@ function App() {
   return (
     <>
       <CustomModal />
-      <ModalWithSelector />
       <ModalWithHash />
-      <div className="modal-selector"></div>
       <a href="#modal-with-hash">Open modal from anchor without events</a>
     </>
   )

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react"
+import React, { useRef, useEffect } from "react"
 import { createRoot } from "react-dom/client"
 
 import { Modal, ModalContent, useModal, ModalBackdrop } from "./lib"
@@ -36,6 +36,39 @@ function CustomModal() {
   )
 }
 
+function CustomModalOnBody() {
+  const triggerButton = useRef(null)
+  const bodyRef = useRef<HTMLElement | null>(null)
+  const { isOpen, toggle } = useModal({
+    triggerRef: triggerButton,
+  })
+
+  useEffect(() => {
+    bodyRef.current = document.body
+  }, [])
+
+  return (
+    <>
+      {/* `triggerRef` allows the focus to shift to whatever triggered the modal, on close. */}
+      <button ref={triggerButton} onClick={toggle}>
+        Open the modal (Append to body)
+      </button>
+
+      {isOpen && bodyRef.current && (
+        <Modal renderTo={bodyRef.current} className={styles.CustomModalAbsolute}>
+          <ModalBackdrop onClick={toggle} className={styles.CustomModalOverlay} />
+          <ModalContent className={classnames([styles.CustomModalContent])}>
+            <button onClick={toggle} className={styles.CustomModalClose}>
+              Close
+            </button>
+            <p>Voluptate Lorem ut minim excepteur sit fugiat anim magna aliquip.</p>
+          </ModalContent>
+        </Modal>
+      )}
+    </>
+  )
+}
+
 function ModalWithHash() {
   const triggerButton = useRef(null)
   const modalRootRef = useRef(null)
@@ -47,7 +80,7 @@ function ModalWithHash() {
   return (
     <>
       <button ref={triggerButton} onClick={toggle}>
-        Using a hash
+        Open the modal using a hash
       </button>
       <div ref={modalRootRef}></div>
 
@@ -70,8 +103,11 @@ function App() {
   return (
     <>
       <CustomModal />
+      <CustomModalOnBody />
       <ModalWithHash />
-      <a href="#modal-with-hash">Open modal from anchor without events</a>
+      <a href="#modal-with-hash">
+        Open modal using exisiting hash (#modal-with-hash) without events
+      </a>
     </>
   )
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,11 +16,67 @@ function CustomModal() {
     <>
       {/* `triggerRef` allows the focus to shift to whatever triggered the modal, on close. */}
       <button ref={triggerButton} onClick={toggle}>
-        Open the modal window!
+        Open the modal (body)
       </button>
 
       {isOpen && (
-        <Modal appendToBody>
+        <Modal>
+          <ModalBackdrop onClick={toggle} className={styles.CustomModalOverlay} />
+          <ModalContent className={classnames([styles.CustomModalContent])}>
+            <button onClick={toggle} className={styles.CustomModalClose}>
+              Close
+            </button>
+            <p>Voluptate Lorem ut minim excepteur sit fugiat anim magna aliquip.</p>
+          </ModalContent>
+        </Modal>
+      )}
+    </>
+  )
+}
+
+function ModalWithSelector() {
+  const triggerButton = useRef(null)
+  const { isOpen, toggle } = useModal({
+    triggerRef: triggerButton,
+  })
+
+  return (
+    <>
+      {/* `triggerRef` allows the focus to shift to whatever triggered the modal, on close. */}
+      <button ref={triggerButton} onClick={toggle}>
+        Open the modal (selector)
+      </button>
+
+      {isOpen && (
+        <Modal renderTo={".modal-selector"}>
+          <ModalBackdrop onClick={toggle} className={styles.CustomModalOverlay} />
+          <ModalContent className={classnames([styles.CustomModalContent])}>
+            <button onClick={toggle} className={styles.CustomModalClose}>
+              Close
+            </button>
+            <p>Voluptate Lorem ut minim excepteur sit fugiat anim magna aliquip.</p>
+          </ModalContent>
+        </Modal>
+      )}
+    </>
+  )
+}
+
+function ModalRenderInPlace() {
+  const triggerButton = useRef(null)
+  const { isOpen, toggle } = useModal({
+    triggerRef: triggerButton,
+  })
+
+  return (
+    <>
+      {/* `triggerRef` allows the focus to shift to whatever triggered the modal, on close. */}
+      <button ref={triggerButton} onClick={toggle}>
+        Open modal (in place - &quot;parent&quot;)
+      </button>
+
+      {isOpen && (
+        <Modal renderTo={"parent"}>
           <ModalBackdrop onClick={toggle} className={styles.CustomModalOverlay} />
           <ModalContent className={classnames([styles.CustomModalContent])}>
             <button onClick={toggle} className={styles.CustomModalClose}>
@@ -36,6 +92,7 @@ function CustomModal() {
 
 function ModalWithHash() {
   const triggerButton = useRef(null)
+  const modalRootRef = useRef(null)
   const { isOpen, toggle } = useModal({
     triggerRef: triggerButton,
     hash: "modal-with-hash",
@@ -44,11 +101,12 @@ function ModalWithHash() {
   return (
     <>
       <button ref={triggerButton} onClick={toggle}>
-        Using a hash
+        Using a hash (HTMLElement)
       </button>
+      <div ref={modalRootRef} className="modal-ref"></div>
 
-      {isOpen && (
-        <Modal>
+      {isOpen && modalRootRef.current && (
+        <Modal renderTo={modalRootRef.current}>
           <ModalBackdrop onClick={toggle} className={styles.CustomModalOverlay} />
           <ModalContent className={styles.CustomModalContent}>
             <button onClick={toggle} className={styles.CustomModalClose}>
@@ -66,7 +124,10 @@ function App() {
   return (
     <>
       <CustomModal />
+      <ModalWithSelector />
       <ModalWithHash />
+      <ModalRenderInPlace />
+      <div className="modal-selector"></div>
       <a href="#modal-with-hash">Open modal from anchor without events</a>
     </>
   )

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -62,34 +62,6 @@ function ModalWithSelector() {
   )
 }
 
-function ModalRenderInPlace() {
-  const triggerButton = useRef(null)
-  const { isOpen, toggle } = useModal({
-    triggerRef: triggerButton,
-  })
-
-  return (
-    <>
-      {/* `triggerRef` allows the focus to shift to whatever triggered the modal, on close. */}
-      <button ref={triggerButton} onClick={toggle}>
-        Open modal (in place - &quot;parent&quot;)
-      </button>
-
-      {isOpen && (
-        <Modal renderTo={"parent"}>
-          <ModalBackdrop onClick={toggle} className={styles.CustomModalOverlay} />
-          <ModalContent className={classnames([styles.CustomModalContent])}>
-            <button onClick={toggle} className={styles.CustomModalClose}>
-              Close
-            </button>
-            <p>Voluptate Lorem ut minim excepteur sit fugiat anim magna aliquip.</p>
-          </ModalContent>
-        </Modal>
-      )}
-    </>
-  )
-}
-
 function ModalWithHash() {
   const triggerButton = useRef(null)
   const modalRootRef = useRef(null)
@@ -126,7 +98,6 @@ function App() {
       <CustomModal />
       <ModalWithSelector />
       <ModalWithHash />
-      <ModalRenderInPlace />
       <div className="modal-selector"></div>
       <a href="#modal-with-hash">Open modal from anchor without events</a>
     </>


### PR DESCRIPTION
<!--
Use the following format as PR title:

[docs/hooks] fix/release/feature/patch: title of pr
-->

## Description

This PR addresses issue #20 by removing the appendToBody prop and introducing the renderTo prop for the Modal component.

## Solution

- Added the renderTo prop, accepting both a string selector or an HTMLElement.
- Removed the appendToBody prop.
- If renderTo is a string, the modal will be appended to the element selected by document.querySelector. If it’s an HTMLElement, the modal will render in that element. If renderTo is not provided or fails, the modal defaults to document.body.

## Additional Notes

This is a breaking change.

## Screenshots

https://github.com/wethegit/react-modal/assets/80900245/5a692973-2e86-4c64-8ec6-346d2a537b4b

