### PR TITLE
fix: update `useModal` args to be optional

### DIFF
--- a/src/lib/hooks/use-modal.ts
+++ b/src/lib/hooks/use-modal.ts
@@ -16,8 +16,8 @@ export interface UseModalOptions {
   hash?: string
 }
 
-export function useModal(props: UseModalOptions) {
-  const { triggerRef, hash } = props || {}
+export function useModal(props: UseModalOptions = {}) {
+  const { triggerRef, hash } = props
   const [state, setState] = useState<ModalStates>(ModalStates.CLOSED)
 
   const handleClose = useCallback(() => {


### PR DESCRIPTION
## Description

This PR updates the `props` argument of `useModal` to default to an empty object when not provided any arguments.

Fixes #62.

## Solution

This change makes it a little bit easier to use the package and follows the doc examples.
