### PR TITLE
Add package.json to release workflow paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - src/**
       - types/**
+      - package.json
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
## Description

Missing `package.json` in release CI.

Closes #142 